### PR TITLE
catch potential GeneratorException from jflex and use logger to feed back to user

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Jun 25 17:45:46 CEST 2016
+#Mon May 08 18:47:37 BST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-bin.zip

--- a/src/main/groovy/org/xbib/gradle/task/JFlexTask.groovy
+++ b/src/main/groovy/org/xbib/gradle/task/JFlexTask.groovy
@@ -1,11 +1,13 @@
-package org.xbib.gradle.task;
+package org.xbib.gradle.task
 
+import jflex.GeneratorException
 import jflex.Main
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.FileVisitDetails
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.StopActionException
 import org.gradle.api.tasks.TaskAction
 
 class JFlexTask extends DefaultTask {
@@ -26,12 +28,30 @@ class JFlexTask extends DefaultTask {
     }
 
     private void generateJflex() {
-        project.fileTree(dir:source, include:'**/*.jflex').visit { FileVisitDetails file ->
-            if (file.isDirectory()) {
-                return
+        def flexFiles = project.fileTree(dir:source, include:'**/*.jflex')
+
+        if(flexFiles.filter {!it.directory}.empty) {
+            logger.warn("no flex files found")
+        } else {
+            flexFiles.visit { FileVisitDetails file ->
+                if (file.isDirectory()) {
+                    return
+                }
+
+                try {
+                    def args = ['-q', file.file.absolutePath,
+                                '-d', project.file("$generateDir/${file.relativePath.parent}").absolutePath + '/'] as String[]
+
+                    logger.debug "running jflex $args"
+
+                    Main.generate(args)
+
+                    logger.info "Java code generated from JFlex file : $file.relativePath"
+                } catch (GeneratorException e) {
+                    logger.error("JFlex $e.message", e)
+                    throw new StopActionException('error occurred during JFlex code generation')
+                }
             }
-            Main.generate(['-q', file.file.absolutePath,
-                           '-d', project.file("$generateDir/${file.relativePath.parent}").absolutePath + '/'] as String[])
         }
     }
 }


### PR DESCRIPTION
as per the problems I was having in issue #2. I started using a task written directly in my `build.gradle` which logged problems when there was an error in jflex. It was pretty helpful so I thought it best to contribute the relevant changes. 