### PR TITLE
Make the JFlexTask cacheable

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = org.xbib.gradle.plugin
-version = 1.2.1
+version = 1.2.2-SNAPSHOT

--- a/src/main/groovy/org/xbib/gradle/task/JFlexTask.groovy
+++ b/src/main/groovy/org/xbib/gradle/task/JFlexTask.groovy
@@ -4,15 +4,20 @@ import jflex.GeneratorException
 import jflex.Main
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.FileVisitDetails
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.StopActionException
 import org.gradle.api.tasks.TaskAction
 
+@CacheableTask
 class JFlexTask extends DefaultTask {
 
     @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
     @Optional
     File source = project.file('src/main/jflex')
 


### PR DESCRIPTION
The output of the jflex task becomes cacheable and repeated builds don't need to execute the task again.