### PR TITLE
Make JFlex compatible with the Gradle Configuration Cache

### DIFF
--- a/src/main/groovy/org/xbib/gradle/plugin/JFlexExtension.groovy
+++ b/src/main/groovy/org/xbib/gradle/plugin/JFlexExtension.groovy
@@ -1,70 +1,53 @@
 package org.xbib.gradle.plugin
 
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Optional
 
 abstract class JFlexExtension {
 
-    @Input
-    @Optional
-    String encoding
+    abstract Property<String> getEncoding()
 
-    @Input
-    @Optional
-    File rootDirectory
+    abstract DirectoryProperty getRootDirectory()
 
-    @Input
-    @Optional
-    File skel
+    abstract RegularFileProperty getSkel()
 
-    @Input
-    @Optional
-    Boolean verbose = false
+    abstract Property<Boolean> getVerbose()
 
-    @Input
-    @Optional
-    Boolean jlex = false
+    abstract Property<Boolean> getJlex()
 
-    @Input
-    @Optional
-    Boolean no_minimize = false
+    abstract Property<Boolean> getNo_minimize()
 
-    @Input
-    @Optional
-    Boolean no_backup = false
+    abstract Property<Boolean> getNo_backup()
 
-    @Input
-    @Optional
-    Boolean unused_warning = false
+    abstract Property<Boolean> getUnused_warning()
 
-    @Input
-    @Optional
-    Boolean progress = false
+    abstract Property<Boolean> getProgress()
 
-    @Input
-    @Optional
-    Boolean time = false
+    abstract Property<Boolean> getTime()
 
-    @Input
-    @Optional
-    Boolean dot = false
+    abstract Property<Boolean> getDot()
 
-    @Input
-    @Optional
-    Boolean dump = false
+    abstract Property<Boolean> getDump()
 
-    @Input
-    @Optional
-    Boolean legacy_dot = false
+    abstract Property<Boolean> getLegacy_dot()
 
-    @Input
-    @Optional
-    Boolean statistics = false
+    abstract Property<Boolean> getStatistics()
 
     abstract Property<Boolean> getWriteIntoJavaSrc()
 
     JFlexExtension() {
+        verbose.convention(false)
+        jlex.convention(false)
+        no_minimize.convention(false)
+        no_backup.convention(false)
+        unused_warning.convention(false)
+        progress.convention(false)
+        time.convention(false)
+        dot.convention(false)
+        dump.convention(false)
+        legacy_dot.convention(false)
+        statistics.convention(false)
         writeIntoJavaSrc.convention(false)
     }
 }

--- a/src/main/groovy/org/xbib/gradle/plugin/JFlexExtension.groovy
+++ b/src/main/groovy/org/xbib/gradle/plugin/JFlexExtension.groovy
@@ -1,9 +1,10 @@
 package org.xbib.gradle.plugin
 
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 
-class JFlexExtension {
+abstract class JFlexExtension {
 
     @Input
     @Optional
@@ -61,7 +62,9 @@ class JFlexExtension {
     @Optional
     Boolean statistics = false
 
-    @Input
-    @Optional
-    Boolean writeIntoJavaSrc = false
+    abstract Property<Boolean> getWriteIntoJavaSrc()
+
+    JFlexExtension() {
+        writeIntoJavaSrc.convention(false)
+    }
 }

--- a/src/main/groovy/org/xbib/gradle/plugin/JFlexPlugin.groovy
+++ b/src/main/groovy/org/xbib/gradle/plugin/JFlexPlugin.groovy
@@ -15,13 +15,13 @@ class JFlexPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         logger.info "JFlex plugin says hello"
+        def extension = createJflexExtension(project)
         project.with {
             apply plugin: 'java-library'
-            createJflexExtension(project)
             addSourceSetExtensions(project)
         }
         project.afterEvaluate {
-            addJFlexTasks(project)
+            addJFlexTasks(project, extension)
         }
     }
 
@@ -52,17 +52,17 @@ class JFlexPlugin implements Plugin<Project> {
         }
     }
 
-    private static void createJflexExtension(Project project) {
+    private static JFlexExtension createJflexExtension(Project project) {
         project.extensions.create ('jflex', JFlexExtension)
     }
 
-    private static void addJFlexTasks(Project project) {
+    private static void addJFlexTasks(Project project, JFlexExtension jFlexExtension) {
         project.sourceSets.all { SourceSet sourceSet ->
-            addJFlexTaskForSourceSet(project, sourceSet)
+            addJFlexTaskForSourceSet(project, sourceSet, jFlexExtension)
         }
     }
 
-    private static void addJFlexTaskForSourceSet(Project project, SourceSet sourceSet) {
+    private static void addJFlexTaskForSourceSet(Project project, SourceSet sourceSet, JFlexExtension jFlexExtension) {
         String taskName = sourceSet.getTaskName('generate', 'jflex')
         SourceDirectorySet sourceDirectorySet = sourceSet.extensions.getByName('jflex') as SourceDirectorySet
         File targetFile = project.file("${project.buildDir}/generated/sources/${sourceSet.name}")

--- a/src/main/groovy/org/xbib/gradle/plugin/JFlexPlugin.groovy
+++ b/src/main/groovy/org/xbib/gradle/plugin/JFlexPlugin.groovy
@@ -71,7 +71,7 @@ class JFlexPlugin implements Plugin<Project> {
                 group = 'jflex'
                 description = 'Generates code from JFlex files in ' + sourceSet.name
                 source = sourceDirectorySet.asList()
-                target = targetFile
+                target.set(targetFile)
                 theSourceSet = sourceSet
             }
             logger.info "created ${taskName} for sources ${sourceDirectorySet.asList()} and target ${targetFile}"

--- a/src/main/groovy/org/xbib/gradle/plugin/JFlexPlugin.groovy
+++ b/src/main/groovy/org/xbib/gradle/plugin/JFlexPlugin.groovy
@@ -88,6 +88,23 @@ class JFlexPlugin implements Plugin<Project> {
             description = 'Generates code from JFlex files in ' + sourceSet.name
             source = sourceDirectorySet.asList()
             target.fileProvider(targetFile)
+
+            encoding.set(jFlexExtension.encoding)
+            rootDirectory.set(jFlexExtension.rootDirectory)
+            skel.set(jFlexExtension.skel)
+            verbose.set(jFlexExtension.verbose)
+            jlex.set(jFlexExtension.jlex)
+            no_minimize.set(jFlexExtension.no_minimize)
+            no_backup.set(jFlexExtension.no_backup)
+            unused_warning.set(jFlexExtension.unused_warning)
+            progress.set(jFlexExtension.progress)
+            time.set(jFlexExtension.time)
+            dot.set(jFlexExtension.dot)
+            dump.set(jFlexExtension.dump)
+            legacy_dot.set(jFlexExtension.legacy_dot)
+            statistics.set(jFlexExtension.statistics)
+            writeIntoJavaSrc.set(jFlexExtension.writeIntoJavaSrc)
+
         }
         logger.info "created ${taskName} for sources ${sourceDirectorySet.asList()} and target ${targetFile}"
         project.tasks.named(sourceSet.compileJavaTaskName).configure({

--- a/src/main/groovy/org/xbib/gradle/plugin/JFlexTask.groovy
+++ b/src/main/groovy/org/xbib/gradle/plugin/JFlexTask.groovy
@@ -36,29 +36,29 @@ abstract class JFlexTask extends DefaultTask {
     @TaskAction
     void generateAndTransformJflex() throws Exception {
         JFlexExtension ext = project.extensions.findByType(JFlexExtension)
-        Options.setRootDirectory(ext.rootDirectory ? ext.rootDirectory : new File(""))
+        Options.setRootDirectory(ext.rootDirectory.asFile.getOrElse(new File("")))
         Skeleton.readDefault()
-        if (ext.skel) {
-            Skeleton.readSkelFile(ext.skel)
+        if (ext.skel.isPresent()) {
+            Skeleton.readSkelFile(ext.skel.get().asFile)
         }
-        Options.encoding = ext.encoding ? Charset.forName(ext.encoding) : Charset.defaultCharset()
-        Options.verbose = ext.verbose
-        Options.progress = ext.progress
-        Options.unused_warning = ext.unused_warning
-        Options.jlex = ext.jlex
-        Options.no_minimize = ext.no_minimize
-        Options.no_backup = ext.no_backup
-        Options.time = ext.time
-        Options.dot = ext.dot
-        Options.dump = ext.dump
-        Options.legacy_dot = ext.legacy_dot
+        Options.encoding = ext.encoding.map({ Charset.forName(it) }).getOrElse(Charset.defaultCharset())
+        Options.verbose = ext.verbose.get()
+        Options.progress = ext.progress.get()
+        Options.unused_warning = ext.unused_warning.get()
+        Options.jlex = ext.jlex.get()
+        Options.no_minimize = ext.no_minimize.get()
+        Options.no_backup = ext.no_backup.get()
+        Options.time = ext.time.get()
+        Options.dot = ext.dot.get()
+        Options.dump = ext.dump.get()
+        Options.legacy_dot = ext.legacy_dot.get()
         File targetFile = target.get().asFile
         source.each { file ->
             String pkg = getPackageName(file)
-            File fullTarget = new File(targetFile, pkg.replace('.','/'))
+            File fullTarget = new File(targetFile, pkg.replace('.', '/'))
             fullTarget.mkdirs()
             Options.directory = fullTarget
-            logger.info "jflex task: source=${file} pkg=${pkg} dir=${targetFile}"
+            logger.info "jflex task: source=${file} pkg=${pkg} dir=${target}"
             try {
                 new LexGenerator(file).generate()
             } catch (GeneratorException e) {
@@ -66,7 +66,7 @@ abstract class JFlexTask extends DefaultTask {
                 throw new StopActionException('an error occurred during JFlex code generation')
             }
         }
-        if (ext.statistics) {
+        if (ext.statistics.get()) {
             Out.statistics()
         }
     }

--- a/src/main/groovy/org/xbib/gradle/plugin/JFlexTask.groovy
+++ b/src/main/groovy/org/xbib/gradle/plugin/JFlexTask.groovy
@@ -57,7 +57,7 @@ abstract class JFlexTask extends DefaultTask {
         Options.legacy_dot = ext.legacy_dot
         File targetFile = target.get().asFile
         // hack for writing directly into java source. Not recommended.
-        if (ext.writeIntoJavaSrc) {
+        if (ext.writeIntoJavaSrc.get()) {
             if (theSourceSet.java && theSourceSet.java.srcDirs) {
                 logger.info "java sources: ${theSourceSet.java.srcDirs}"
                 targetFile = theSourceSet.java.srcDirs.first()

--- a/src/main/groovy/org/xbib/gradle/plugin/JFlexTask.groovy
+++ b/src/main/groovy/org/xbib/gradle/plugin/JFlexTask.groovy
@@ -7,11 +7,17 @@ import jflex.option.Options
 import jflex.skeleton.Skeleton
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -26,6 +32,56 @@ abstract class JFlexTask extends DefaultTask {
 
     private final Logger logger = Logging.getLogger(JFlexTask)
 
+    @Input
+    @Optional
+    abstract Property<String> getEncoding()
+
+    @InputDirectory
+    @Optional
+    @PathSensitive(PathSensitivity.RELATIVE)
+    abstract DirectoryProperty getRootDirectory()
+
+    @InputFile
+    @Optional
+    @PathSensitive(PathSensitivity.RELATIVE)
+    abstract RegularFileProperty getSkel()
+
+    @Input
+    abstract Property<Boolean> getVerbose()
+
+    @Input
+    abstract Property<Boolean> getJlex()
+
+    @Input
+    abstract Property<Boolean> getNo_minimize()
+
+    @Input
+    abstract Property<Boolean> getNo_backup()
+
+    @Input
+    abstract Property<Boolean> getUnused_warning()
+
+    @Input
+    abstract Property<Boolean> getProgress()
+
+    @Input
+    abstract Property<Boolean> getTime()
+
+    @Input
+    abstract Property<Boolean> getDot()
+
+    @Input
+    abstract Property<Boolean> getDump()
+
+    @Input
+    abstract Property<Boolean> getLegacy_dot()
+
+    @Input
+    abstract Property<Boolean> getStatistics()
+
+    @Input
+    abstract Property<Boolean> getWriteIntoJavaSrc()
+
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
     Iterable<File> source
@@ -35,23 +91,22 @@ abstract class JFlexTask extends DefaultTask {
 
     @TaskAction
     void generateAndTransformJflex() throws Exception {
-        JFlexExtension ext = project.extensions.findByType(JFlexExtension)
-        Options.setRootDirectory(ext.rootDirectory.asFile.getOrElse(new File("")))
+        Options.setRootDirectory(rootDirectory.asFile.getOrElse(new File("")))
         Skeleton.readDefault()
-        if (ext.skel.isPresent()) {
-            Skeleton.readSkelFile(ext.skel.get().asFile)
+        if (skel.isPresent()) {
+            Skeleton.readSkelFile(skel.get().asFile)
         }
-        Options.encoding = ext.encoding.map({ Charset.forName(it) }).getOrElse(Charset.defaultCharset())
-        Options.verbose = ext.verbose.get()
-        Options.progress = ext.progress.get()
-        Options.unused_warning = ext.unused_warning.get()
-        Options.jlex = ext.jlex.get()
-        Options.no_minimize = ext.no_minimize.get()
-        Options.no_backup = ext.no_backup.get()
-        Options.time = ext.time.get()
-        Options.dot = ext.dot.get()
-        Options.dump = ext.dump.get()
-        Options.legacy_dot = ext.legacy_dot.get()
+        Options.encoding = encoding.map({ Charset.forName(it) }).getOrElse(Charset.defaultCharset())
+        Options.verbose = verbose.get()
+        Options.progress = progress.get()
+        Options.unused_warning = unused_warning.get()
+        Options.jlex = jlex.get()
+        Options.no_minimize = no_minimize.get()
+        Options.no_backup = no_backup.get()
+        Options.time = time.get()
+        Options.dot = dot.get()
+        Options.dump = dump.get()
+        Options.legacy_dot = legacy_dot.get()
         File targetFile = target.get().asFile
         source.each { file ->
             String pkg = getPackageName(file)
@@ -66,7 +121,7 @@ abstract class JFlexTask extends DefaultTask {
                 throw new StopActionException('an error occurred during JFlex code generation')
             }
         }
-        if (ext.statistics.get()) {
+        if (statistics.get()) {
             Out.statistics()
         }
     }

--- a/src/main/groovy/org/xbib/gradle/plugin/JFlexTask.groovy
+++ b/src/main/groovy/org/xbib/gradle/plugin/JFlexTask.groovy
@@ -56,7 +56,7 @@ abstract class JFlexTask extends DefaultTask {
         source.each { file ->
             String pkg = getPackageName(file)
             File fullTarget = new File(targetFile, pkg.replace('.','/'))
-            project.mkdir(fullTarget)
+            fullTarget.mkdirs()
             Options.directory = fullTarget
             logger.info "jflex task: source=${file} pkg=${pkg} dir=${targetFile}"
             try {

--- a/src/main/groovy/org/xbib/gradle/plugin/JFlexTask.groovy
+++ b/src/main/groovy/org/xbib/gradle/plugin/JFlexTask.groovy
@@ -33,9 +33,6 @@ abstract class JFlexTask extends DefaultTask {
     @OutputDirectory
     abstract DirectoryProperty getTarget()
 
-    @Internal
-    SourceSet theSourceSet
-
     @TaskAction
     void generateAndTransformJflex() throws Exception {
         JFlexExtension ext = project.extensions.findByType(JFlexExtension)
@@ -56,16 +53,6 @@ abstract class JFlexTask extends DefaultTask {
         Options.dump = ext.dump
         Options.legacy_dot = ext.legacy_dot
         File targetFile = target.get().asFile
-        // hack for writing directly into java source. Not recommended.
-        if (ext.writeIntoJavaSrc.get()) {
-            if (theSourceSet.java && theSourceSet.java.srcDirs) {
-                logger.info "java sources: ${theSourceSet.java.srcDirs}"
-                targetFile = theSourceSet.java.srcDirs.first()
-                logger.info "switching to first java source directory ${targetFile}"
-            } else {
-                logger.warn "writing into java source not possible, is empty"
-            }
-        }
         source.each { file ->
             String pkg = getPackageName(file)
             File fullTarget = new File(targetFile, pkg.replace('.','/'))

--- a/src/test/groovy/org/xbib/gradle/plugin/test/JFlexPluginTest.groovy
+++ b/src/test/groovy/org/xbib/gradle/plugin/test/JFlexPluginTest.groovy
@@ -191,4 +191,48 @@ gradle.buildFinished {
                 .forwardOutput()
                 .build()
     }
+
+    @Test
+    void testCanLoadTaskFromConfigurationCache() {
+        String settingsFileContent = '''
+rootProject.name = 'jflex-test'
+'''
+        settingsFile.write(settingsFileContent)
+        String buildFileContent = '''
+plugins {
+    id 'org.xbib.gradle.plugin.jflex'
+}
+
+sourceSets {
+  test {
+     jflex {
+       // point to our test directory where the jflex file lives
+       srcDir "${providers.systemProperty('user.dir')}/src/test/jflex"
+     }
+  }
+}
+
+jflex {
+   verbose = true
+   dump = false
+   progress = false
+}
+'''
+        buildFile.write(buildFileContent)
+        GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withArguments("--configuration-cache", ":generateJflex")
+                .withPluginClasspath()
+                .forwardOutput()
+                .build()
+
+        BuildResult result = GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withArguments("--configuration-cache", ":generateJflex")
+                .withPluginClasspath()
+                .forwardOutput()
+                .build()
+
+        assertTrue(result.output.contains("Reusing configuration cache."))
+    }
 }


### PR DESCRIPTION
👋 Hello, I'm an engineer at Gradle and I came across your project in the scope of another project [opentelemetry-java-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation/). 

The [Gradle Configuration Cache](https://docs.gradle.org/7.3.2/userguide/configuration_cache.html) enables faster build times by caching task configuration on the local file system. This pull request does makes the JFlex task compatible with the configuration cache by changing the structure of the task so that it is better understood by Gradle at configuration time. This includes:

- Adding a test to verify the task is compatible with the configuration task 
- Modifying the `JFlexPlugin` to not rely on `afterEvaluate`
- Extract usage of `SourceSet` from the `JFlexTask` at execution time per recommendations [here](https://docs.gradle.org/7.5.1/userguide/configuration_cache.html#config_cache:requirements:disallowed_types)
- Remove usage of `project` invocations at project execution time. This required re-wiring the task inputs into a slightly more idiomatic way. Tasks aren't supposed to reference extensions directly but rather plugins have the responsibility of mapping extension properties to task inputs. 

A slightly more idiomatic approach would be to remove the `JFlexExtension` altogether and instead have users configure the `JFlexTask` directly using the following code:

```kotlin

tasks.withType<org.xbib.gradle.plugin.JFlexTask>() {
// configuration here with sensible defaults defined in `JFlexTask`
}
```

but that would cause a breaking change for users who currently configure this plugin via the extension, which isn't ideal. I think the current approach is reasonable. 